### PR TITLE
chore(install): Including the make install command

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,5 +1,7 @@
 TEST?=$$(go list ./... |grep -v 'vendor')
 GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
+VERSION?=0.3.0
+TF_PLUGINS_DIR?=$(HOME)/.terraform.d/plugins/$$(go env GOOS)_$$(go env GOARCH)
 TARGETS=darwin linux windows
 WEBSITE_REPO=github.com/hashicorp/terraform-website
 PKG_NAME=circleci
@@ -7,7 +9,11 @@ PKG_NAME=circleci
 default: build
 
 build: fmtcheck
-	go build -o terraform-provider-circleci main.go
+	go build -o terraform-provider-circleci_v$(VERSION) main.go
+
+install: build
+	mkdir -p $(TF_PLUGINS_DIR)
+	mv terraform-provider-circleci_v$(VERSION) $(TF_PLUGINS_DIR)
 
 targets: $(TARGETS)
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,20 @@ CircleCI Terraform Provider
 Setup
 -----
 
+Using the latest version of the plugin
+
 ```hcl
 provider "circleci" {
-  token = "<CircleCI Token>" // Will fallback to CIRCLECI_TOKEN environment variable if not explicitly specified
+  token   = "<CircleCI Token>" # Will fallback to CIRCLECI_TOKEN environment variable if not explicitly specified
+}
+```
+
+Or for a different version of the plugin, you can specify it through
+
+```hcl
+provider "circleci" {
+  # considering the CIRCLECI_TOKEN environment variable
+  version = "~>0.3.0"
 }
 ```
 
@@ -121,8 +132,16 @@ In addition to all arguments above, the following attributes are exported:
 
 The `circleci_ssh_key` resource does not support importing.
 
-Building The Provider
----------------------
+Installation
+------------
+
+To build the provider and then install it to the plugins folder, run
+
+```shell
+make install
+```
+
+Otherwise, the binary can be built using
 
 ```shell
 make build


### PR DESCRIPTION
Using go env for GOOS and GOARCH to dynamically build the path for
plugins.
Moving the binary to Terraform plugins path after building, defaults to
user HOME